### PR TITLE
feat: atualiza as tabelas após confirmar ou excluir algum empréstimo

### DIFF
--- a/src/main/java/visao/TelaPrincipal.java
+++ b/src/main/java/visao/TelaPrincipal.java
@@ -564,7 +564,14 @@ public class TelaPrincipal extends javax.swing.JFrame {
                             int id = Integer.parseInt(idObjeto.toString());
                             try {
                                 EmprestimoControle.excluir(id);
+                                carregaTabelaTodos();
+                                carregaTabelaEmDia();
+                                carregaTabelaAtrasados();
+                                carregaTabelaAtivos();
                                 atualizarLabelQuantidadeDeEmprestimos();
+                                
+                                jTabbedDash.revalidate();
+                                jTabbedDash.repaint();
                             } catch (ExceptionDAO ex) {
                                 erro.setVisible(true);
                                 Logger.getLogger(TelaPrincipal.class.getName()).log(Level.SEVERE, null, ex);
@@ -615,6 +622,15 @@ public class TelaPrincipal extends javax.swing.JFrame {
 
                             try {
                                 EmprestimoControle.confirmarDevolucao(id);
+                                
+                                carregaTabelaTodos();
+                                carregaTabelaEmDia();
+                                carregaTabelaAtrasados();
+                                carregaTabelaAtivos();
+                                atualizarLabelQuantidadeDeEmprestimos();
+                                
+                                jTabbedDash.revalidate();
+                                jTabbedDash.repaint();
                             } catch (ExceptionDAO ex) {
                                 erro.setVisible(true);
                                 Logger.getLogger(TelaPrincipal.class.getName()).log(Level.SEVERE, null, ex);


### PR DESCRIPTION
Atualização do Botão de Exclusão e Confirmação para Atualizar Tabelas

O botão de exclusão na aplicação Java Swing estava removendo itens da tabela (JTable) mas não atualizava a interface gráfica de maneira imediata. Os dados eram atualizados somente após mudar a paginação, ocorrendo o mesmo com o botão de confirmação.

Mudanças Realizadas:
Atualização da Tabela Ativa:

Após a exclusão de um item, a linha correspondente é removida diretamente do modelo da tabela.
Adicionadas chamadas a revalidate() e repaint() na JTable ativa para garantir que a interface gráfica seja atualizada imediatamente.
Atualização de Todas as Tabelas no JTabbedPane.